### PR TITLE
Match SmokeSlate pages to original Google Site

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SmokeSlate — About Me</title>
+    <meta name="description" content="Learn more about SmokeSlate, a developer, gamer, and beta tester." />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/site.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="site-header__inner">
+        <a class="site-title" href="index.html">SmokeSlate</a>
+        <nav class="site-nav" data-nav>
+          <a href="index.html">Home</a>
+          <a href="projects.html">Projects</a>
+          <a href="about.html">About Me</a>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <div class="container hero">
+        <h1>About Me</h1>
+        <div class="content-stack">
+          <p>I am a developer, gamer, and beta tester.</p>
+          <p>I like playing VR games, as well as making my own shortcuts and websites.</p>
+        </div>
+      </div>
+    </main>
+
+    <footer class="page-footer">
+      SmokeSlate
+      <span>®2022-2025 All Rights Reserved</span>
+    </footer>
+
+    <script src="assets/js/site.js" defer></script>
+  </body>
+</html>

--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -1,0 +1,257 @@
+:root {
+  --page-bg: #050508;
+  --text-primary: #f0f0f0;
+  --text-muted: #b0b0b8;
+  --accent: #7a5cff;
+  --accent-soft: rgba(122, 92, 255, 0.18);
+  --card-bg: #111118;
+  --card-border: #1f1f2a;
+  --card-shadow: rgba(10, 10, 20, 0.6);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Lato', sans-serif;
+  background: radial-gradient(circle at top, rgba(122, 92, 255, 0.08), transparent 55%), var(--page-bg);
+  color: var(--text-primary);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+a {
+  color: inherit;
+}
+
+a:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+}
+
+.site-header {
+  border-top: 4px solid var(--accent);
+  background: rgba(5, 5, 10, 0.92);
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.site-header__inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 20px 24px 18px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.site-title {
+  font-size: 1.35rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-decoration: none;
+}
+
+.site-nav {
+  display: flex;
+  align-items: center;
+  gap: 22px;
+  font-size: 0.95rem;
+}
+
+.site-nav a {
+  text-decoration: none;
+  color: rgba(240, 240, 240, 0.78);
+  transition: color 0.2s ease;
+}
+
+.site-nav a:hover,
+.site-nav a:focus {
+  color: var(--text-primary);
+}
+
+.site-nav a.is-active {
+  color: var(--text-primary);
+  text-decoration: underline;
+  text-decoration-color: var(--accent);
+  text-decoration-thickness: 2px;
+  text-underline-offset: 6px;
+}
+
+main {
+  flex: 1;
+  padding: 56px 0 80px;
+}
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.hero {
+  text-align: center;
+  margin-bottom: 96px;
+}
+
+.hero h1 {
+  font-size: clamp(2.8rem, 6vw, 3.6rem);
+  margin: 0 0 12px;
+  letter-spacing: 0.02em;
+}
+
+.hero p {
+  margin: 8px 0 0;
+  font-size: clamp(1.05rem, 2vw, 1.2rem);
+  color: rgba(240, 240, 240, 0.82);
+  line-height: 1.6;
+}
+
+.section-heading {
+  text-align: center;
+  margin: 0;
+  font-size: 2.1rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.section-heading a {
+  color: inherit;
+  text-decoration: none;
+  padding-bottom: 6px;
+  border-bottom: 3px solid var(--accent);
+  box-shadow: inset 0 -6px 0 var(--accent-soft);
+}
+
+.projects-grid {
+  margin-top: 52px;
+  display: grid;
+  gap: 36px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.project-card {
+  display: block;
+  text-decoration: none;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 32px;
+  padding: 26px 26px 32px;
+  box-shadow: 0 18px 40px var(--card-shadow);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.project-card:hover,
+.project-card:focus {
+  transform: translateY(-8px);
+  box-shadow: 0 26px 48px rgba(15, 15, 25, 0.7);
+}
+
+.project-card img {
+  width: 100%;
+  height: auto;
+  border-radius: 24px;
+  display: block;
+  margin-bottom: 22px;
+  background: #09090f;
+}
+
+.project-date {
+  display: block;
+  font-size: 0.8rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(122, 92, 255, 0.8);
+  margin-bottom: 12px;
+}
+
+.project-title {
+  display: block;
+  font-size: 1.35rem;
+  font-weight: 700;
+  margin-bottom: 12px;
+}
+
+.project-desc {
+  display: block;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: var(--text-muted);
+}
+
+.empty-state {
+  color: var(--text-muted);
+  text-align: center;
+  grid-column: 1 / -1;
+}
+
+.page-footer {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  text-align: center;
+  padding: 28px 16px 40px;
+  font-size: 0.95rem;
+  color: rgba(240, 240, 240, 0.72);
+}
+
+.page-footer span {
+  display: block;
+  margin-top: 6px;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+}
+
+.lede {
+  max-width: 680px;
+  margin: 0 auto;
+  font-size: 1.05rem;
+  line-height: 1.75;
+  color: rgba(240, 240, 240, 0.82);
+}
+
+.content-stack {
+  display: grid;
+  gap: 28px;
+  margin-top: 48px;
+}
+
+.content-stack .project-card {
+  max-width: 420px;
+  margin: 0 auto;
+}
+
+.content-stack p {
+  margin: 0;
+  font-size: 1.02rem;
+  line-height: 1.8;
+  color: rgba(240, 240, 240, 0.82);
+  text-align: center;
+}
+
+@media (max-width: 640px) {
+  .site-header__inner {
+    flex-direction: column;
+    justify-content: center;
+    text-align: center;
+  }
+
+  .site-nav {
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 16px;
+  }
+
+  main {
+    padding: 40px 0 72px;
+  }
+
+  .projects-grid {
+    gap: 28px;
+  }
+
+  .project-card {
+    padding: 22px 22px 28px;
+  }
+}

--- a/assets/js/site.js
+++ b/assets/js/site.js
@@ -1,0 +1,106 @@
+async function fetchProjectsData() {
+  const response = await fetch('data/projects.json');
+  if (!response.ok) {
+    throw new Error(`Failed to load projects: ${response.status}`);
+  }
+  const payload = await response.json();
+  return Array.isArray(payload) ? payload : [];
+}
+
+function createProjectCard(project) {
+  const hasLink = Boolean(project.url);
+  const card = document.createElement(hasLink ? 'a' : 'div');
+  card.className = 'project-card';
+
+  if (hasLink) {
+    card.href = project.url;
+    const isExternal = /^https?:\/\//i.test(project.url) && !project.url.startsWith(location.origin);
+    if (isExternal) {
+      card.target = '_blank';
+      card.rel = 'noopener noreferrer';
+    }
+  }
+
+  if (project.image) {
+    const img = document.createElement('img');
+    img.src = project.image;
+    img.alt = project.title ? `${project.title} preview` : 'Project preview';
+    card.appendChild(img);
+  }
+
+  if (project.date) {
+    const date = document.createElement('span');
+    date.className = 'project-date';
+    date.textContent = project.date;
+    card.appendChild(date);
+  }
+
+  const title = document.createElement('span');
+  title.className = 'project-title';
+  title.textContent = project.title || 'Untitled project';
+  card.appendChild(title);
+
+  if (project.description) {
+    const description = document.createElement('span');
+    description.className = 'project-desc';
+    description.textContent = project.description;
+    card.appendChild(description);
+  }
+
+  return card;
+}
+
+async function hydrateProjects(container) {
+  try {
+    const featuredOnly = container.hasAttribute('data-projects-featured');
+    const limitAttr = container.getAttribute('data-projects-limit');
+    const limit = limitAttr ? Number.parseInt(limitAttr, 10) : undefined;
+
+    const data = await fetchProjectsData();
+    let projects = data.slice();
+
+    if (featuredOnly) {
+      projects = projects.filter((item) => item.featured);
+    }
+
+    if (typeof limit === 'number' && Number.isFinite(limit)) {
+      projects = projects.slice(0, limit);
+    }
+
+    if (!projects.length) {
+      container.innerHTML = '<p class="empty-state">Projects will appear here soon.</p>';
+      return;
+    }
+
+    const fragment = document.createDocumentFragment();
+    projects.forEach((project) => {
+      fragment.appendChild(createProjectCard(project));
+    });
+
+    container.innerHTML = '';
+    container.appendChild(fragment);
+  } catch (error) {
+    console.error(error);
+    container.innerHTML = '<p class="empty-state">Unable to load projects right now.</p>';
+  }
+}
+
+function setActiveNav() {
+  const currentPath = window.location.pathname.split('/').pop() || 'index.html';
+  const normalized = currentPath === '' ? 'index.html' : currentPath;
+
+  document.querySelectorAll('[data-nav] a').forEach((link) => {
+    const href = link.getAttribute('href');
+    const isMatch = href === normalized || (href === 'index.html' && normalized === '');
+    if (isMatch) {
+      link.classList.add('is-active');
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  setActiveNav();
+  document.querySelectorAll('[data-projects]').forEach((container) => {
+    hydrateProjects(container);
+  });
+});

--- a/data/projects.json
+++ b/data/projects.json
@@ -1,0 +1,61 @@
+[
+  {
+    "title": "Hosting",
+    "date": "May 20, 2025",
+    "description": "How I host my sites and projects.",
+    "url": "hosting.html",
+    "image": "https://lh3.googleusercontent.com/sitesv/AICyYdbwXZg8Rnsqq3HwCV-1bmIDxDpwDdUIFsOPJw5pQG-38u9v51goerR8W76NsI3TIrPBvYMtE8DsA0TGVLOrXJhaRmashwNec7uwV2Q1izccOjLzfCEFTs-jm9F8nupvoDI1LMLofO2w0eFwWPPmWS6VPILRPCFfuHg2T6CDLYby4L1UVEfLNqgGnmU=w1280",
+    "featured": true
+  },
+  {
+    "title": "ReSite",
+    "date": "February 20, 2025",
+    "description": "My latest project, a service for making sites.",
+    "url": "https://resite.web.app",
+    "image": "https://lh3.googleusercontent.com/sitesv/AICyYdbN97kvd7Vn7g60DIf5X9ltGmU167eQFXqgz__s2IvKP6Efy50CejcGQ01W9H-Zm8Q0-ZXSQ5bjoPeiPC9ZCurSy6-poSBXzOLLS5k_SsliTKHry-zaElB4qRP_ewQriEP_FjpQjgtB7dBSl5vxi2AP-Nkc7M5Xf1BwIPq0GZUnQsDVT_eO1w4TWgke8AB-c1HnlLzMZk2-WXkDL44JUiCcMCiuGrjlIaga=w1280",
+    "featured": true
+  },
+  {
+    "title": "Beat The Bank Online",
+    "date": "Jan 7, 2025 - May 21, 2025",
+    "description": "My online shortcut game!",
+    "url": "https://routinehub.co/shortcut/18289/",
+    "image": "https://lh3.googleusercontent.com/sitesv/AICyYdYpWckJ-9-GyecVTJAVlAxilHpXIbnxzap7o1KSzCl4wJe9miR-lRL6RTWdhn1-7yJIHl8zdOuMwupGxwvQ0hB6ZTQuIf2S0O1-8JOIyYCV3QMXx_bQj315T0OVppDRHFYGac1Svcvj3_mrAiXk9WUgC9Laa0QL3bWWzBOD6SK71DT1xuTGeF5q=w1280",
+    "featured": true
+  },
+  {
+    "title": "iMovie Tools",
+    "date": "April 12, 2025",
+    "description": "A tool to export media and full projects from iMovie.",
+    "url": "https://github.com/SmokeSlate/iMovieTools",
+    "image": "https://lh3.googleusercontent.com/sitesv/AICyYdY0EkfI1CPWXZ-tclmJ5n34yZ2mqwNBX_ENFMNVGPo-PWaDURe1mpxfycmJUlQbWgahRLRK4c3OXXCaV2JbZctSPCCFPKvQFtGPTMKytX8dQ0dC-HT8jldVVG3C-5-iZxKfJqdsj8Z-88yOGNdGt7DxwmYSZi9fY8oD9_wrHLlnF-MREW8s3qXhU3Y=w1280"
+  },
+  {
+    "title": "RoutineHub",
+    "date": "May 21, 2025",
+    "description": "My RoutineHub profile with all my latest shortcuts.",
+    "url": "https://routinehub.co/user/SmokeSlate",
+    "image": "https://lh3.googleusercontent.com/sitesv/AICyYdapOTOJfKXcOlHxWCbu5umMr7nJpn5JmzdHhFKxLADQ2gJbzLpV4d72yv-k5BMykwBRQtcMQjL_dn3vqEYoYQFe0BSG3ywrrzsP3lXmGM_6a-oAzjzQNNPA1mNzoRN5S3rcOA6VoWTf_UDp2-VE6KLPCC3_3ccT0ND9HL0Xfn9CM1OSt8AOaviv5Y2QnZo9_u5gzabLaly7Vb2vQvFOW-hoHy5Kl9ZAoOmyqg=w1280"
+  },
+  {
+    "title": "Calculator Games",
+    "date": "May 21, 2025",
+    "description": "My TI-84 game collection.",
+    "url": "https://calgames.web.app",
+    "image": "https://lh3.googleusercontent.com/sitesv/AICyYdas8JAnQhUEAQ7XuUplA-LtapmIRwe8aBhCzSyvyFYFF74vYPsIZR90ZdUfRCghvyVYe3h0WYzPPlyzkG-tt_jNmrU9HbghcNN6Z1QrldpmljIPDV6g2GckftqZb1CL39HpOTmA-TvZJNxmjK_PZf3UqkdTjUkkOZGAtXkGxKChIjtMcgYmt8Nbphe-8tHBotb6R9m-b1klciCWyQZuCzECwzsCwHKRNYZ-zoENwDFEamGXpVsUVZIoMVlGcc=w1280"
+  },
+  {
+    "title": "Icon Maker",
+    "date": "February 15, 2024",
+    "description": "Make icons for your iOS home screen.",
+    "url": "https://routinehub.co/shortcut/12219",
+    "image": "https://lh3.googleusercontent.com/sitesv/AICyYdauPP36Qa0T3uAUoGPBZdHj1xuUpRYoXSOgquNs10QAQfFlvDmwLOehlrCZxhyv6qWDphuNE8iE_huMGd7-sEEyzDhZPa3px5gvi44EVWAmmU7BQgOZAf2EWwBRuE784xz1hj_O5HOM60O_jotKMB49mWJD2J76lSuggLq-4jQQVnauqpMsCXQyzKI-yycOKUF7X411sNYZ-zoENwDFEamGXpVsUVZIoMVlGcc=w1280"
+  },
+  {
+    "title": "Wordle Trainer",
+    "date": "May 21, 2025",
+    "description": "My custom Wordle with a built-in hint.",
+    "url": "https://wordle.smokeslate.xyz",
+    "image": "https://lh3.googleusercontent.com/sitesv/AICyYdaa7lyUVk_BYo3s0ieAs2-mX752_sW_oazcPOWKyRHnx2ieu7ru_HpEiNdYR6HVJusZd41wrZCS-pgy31NRqXlSP8_QcVwbDPxFW3e7ws9_LG-QH4eulXw6tI76DpyeClTUtjD7HsKao99BqZqYffBfvYGe7LUG6mJ1ZkS7kUA9Z_zhVJKjC-S6=w1280"
+  }
+]

--- a/discord.html
+++ b/discord.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SmokeSlate — Discord</title>
+    <meta name="description" content="Join SmokeSlate on Discord." />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/site.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="site-header__inner">
+        <a class="site-title" href="index.html">SmokeSlate</a>
+        <nav class="site-nav" data-nav>
+          <a href="index.html">Home</a>
+          <a href="projects.html">Projects</a>
+          <a href="about.html">About Me</a>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <div class="container hero">
+        <h1>Discord</h1>
+        <div class="content-stack">
+          <p>The community server is still getting ready.</p>
+          <p>Check back soon for shortcuts talk, beta testing, and project updates!</p>
+        </div>
+      </div>
+    </main>
+
+    <footer class="page-footer">
+      SmokeSlate
+      <span>®2022-2025 All Rights Reserved</span>
+    </footer>
+
+    <script src="assets/js/site.js" defer></script>
+  </body>
+</html>

--- a/github.html
+++ b/github.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SmokeSlate — GitHub</title>
+    <meta name="description" content="Follow SmokeSlate projects on GitHub." />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/site.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="site-header__inner">
+        <a class="site-title" href="index.html">SmokeSlate</a>
+        <nav class="site-nav" data-nav>
+          <a href="index.html">Home</a>
+          <a href="projects.html">Projects</a>
+          <a href="about.html">About Me</a>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <div class="container hero">
+        <h1>GitHub</h1>
+        <div class="content-stack">
+          <p>You can find my public repos and experiments over on GitHub.</p>
+          <a class="project-card" href="https://github.com/SmokeSlate" target="_blank" rel="noopener noreferrer">
+            <span class="project-title">@SmokeSlate</span>
+            <span class="project-desc">Browse shortcuts, web utilities, and ongoing projects.</span>
+          </a>
+        </div>
+      </div>
+    </main>
+
+    <footer class="page-footer">
+      SmokeSlate
+      <span>®2022-2025 All Rights Reserved</span>
+    </footer>
+
+    <script src="assets/js/site.js" defer></script>
+  </body>
+</html>

--- a/hosting.html
+++ b/hosting.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SmokeSlate — Hosting</title>
+    <meta name="description" content="How SmokeSlate hosts projects and experiments." />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/site.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="site-header__inner">
+        <a class="site-title" href="index.html">SmokeSlate</a>
+        <nav class="site-nav" data-nav>
+          <a href="index.html">Home</a>
+          <a href="projects.html">Projects</a>
+          <a href="about.html">About Me</a>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <div class="container hero">
+        <h1>Hosting</h1>
+        <div class="content-stack">
+          <p>
+            Hello, I'm SmokeSlate, I use XAMPP for PHP, Google Scripts, and Firebase Hosting for static sites.
+          </p>
+          <p>
+            I host my PHP applications using XAMPP. XAMPP provides an Apache server and MySQL database out of the box, which makes it easy to
+            spin up a working PHP environment without extensive configuration (unless I use it lol).
+          </p>
+          <p>
+            I deploy static and frontend web assets via Firebase Hosting. Firebase makes it easy to push updates with a single CLI command and
+            offers fast, secure hosting with built-in HTTPS and custom domain support.
+          </p>
+          <p>
+            While PHP isn’t natively supported by Firebase Hosting, I often separate the frontend to host on Firebase and use JS to connect to my
+            backend when needed. When I'm developing a simple backend with little to no user data storage, I use Google Apps Script. It has easy Google
+            API integration with a high quota and straightforward collaboration.
+          </p>
+        </div>
+      </div>
+    </main>
+
+    <footer class="page-footer">
+      SmokeSlate
+      <span>®2022-2025 All Rights Reserved</span>
+    </footer>
+
+    <script src="assets/js/site.js" defer></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SmokeSlate</title>
+    <meta
+      name="description"
+      content="SmokeSlate builds websites, apps, shortcuts, Discord bots, and more."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/site.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="site-header__inner">
+        <a class="site-title" href="index.html">SmokeSlate</a>
+        <nav class="site-nav" data-nav>
+          <a href="index.html">Home</a>
+          <a href="projects.html">Projects</a>
+          <a href="about.html">About Me</a>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <div class="container hero">
+        <h1>I'm SmokeSlate,</h1>
+        <p>I make websites, apps, shortcuts, discord bots, run servers and more!</p>
+      </div>
+
+      <section>
+        <div class="container">
+          <h2 class="section-heading"><a href="projects.html">Projects</a></h2>
+          <div class="projects-grid" data-projects data-projects-featured="true">
+            <p class="empty-state">Loading projects…</p>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="page-footer">
+      SmokeSlate
+      <span>®2022-2025 All Rights Reserved</span>
+    </footer>
+
+    <script src="assets/js/site.js" defer></script>
+  </body>
+</html>

--- a/projects.html
+++ b/projects.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SmokeSlate — Projects</title>
+    <meta name="description" content="Browse SmokeSlate projects, shortcuts, and tools." />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/site.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="site-header__inner">
+        <a class="site-title" href="index.html">SmokeSlate</a>
+        <nav class="site-nav" data-nav>
+          <a href="index.html">Home</a>
+          <a href="projects.html">Projects</a>
+          <a href="about.html">About Me</a>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <div class="container hero">
+        <h1>Projects</h1>
+        <p class="lede">A collection of the sites, shortcuts, and experiments I've been building lately.</p>
+      </div>
+
+      <section>
+        <div class="container">
+          <div class="projects-grid" data-projects>
+            <p class="empty-state">Loading projects…</p>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="page-footer">
+      SmokeSlate
+      <span>®2022-2025 All Rights Reserved</span>
+    </footer>
+
+    <script src="assets/js/site.js" defer></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- rebuild the navigation, hero, and footer with a dark Lato theme that mirrors the legacy Google Site layout
- populate project grids from an expanded JSON file that includes featured flags, cover art, and outbound links just like the originals
- restyle the about and hosting pages to reuse the shared chrome and preserve the original copy blocks

## Testing
- python -m json.tool data/projects.json

------
https://chatgpt.com/codex/tasks/task_e_68ceef29c638833084e30e919e3d6f65