### PR TITLE
Simplify site with Tailwind layout

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SmokeSlate — About Me</title>
+    <meta name="description" content="Learn more about SmokeSlate, a developer, gamer, and beta tester." />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            fontFamily: {
+              sans: ['"Work Sans"', 'ui-sans-serif', 'system-ui'],
+            },
+          },
+        },
+      };
+    </script>
+  </head>
+  <body class="bg-white font-sans text-gray-900">
+    <header class="border-b bg-white">
+      <div
+        class="mx-auto flex max-w-5xl flex-col gap-4 px-4 py-6 sm:flex-row sm:items-center sm:justify-between"
+      >
+        <a class="text-2xl font-semibold text-gray-900" href="index.html">SmokeSlate</a>
+        <nav class="flex gap-6 text-sm font-medium text-gray-600" data-nav>
+          <a class="text-gray-600 hover:text-blue-600" href="index.html">Home</a>
+          <a class="text-gray-600 hover:text-blue-600" href="projects.html">Projects</a>
+          <a class="text-gray-600 hover:text-blue-600" href="about.html">About Me</a>
+        </nav>
+      </div>
+    </header>
+
+    <main class="py-16">
+      <div class="mx-auto max-w-3xl px-4 text-center">
+        <h1 class="text-4xl font-semibold text-gray-900 sm:text-5xl">About Me</h1>
+        <div class="mt-8 space-y-4 text-base leading-relaxed text-gray-700">
+          <p>I am a developer, gamer, and beta tester.</p>
+          <p>I like playing VR games, as well as making my own shortcuts and websites.</p>
+        </div>
+      </div>
+    </main>
+
+    <footer class="border-t bg-gray-50">
+      <div class="mx-auto max-w-5xl px-4 py-8 text-center text-sm text-gray-600">
+        <p class="font-semibold text-gray-700">SmokeSlate</p>
+        <p class="mt-1">®2022-2025 All Rights Reserved</p>
+      </div>
+    </footer>
+
+    <script src="assets/js/site.js" defer></script>
+  </body>
+</html>

--- a/assets/js/site.js
+++ b/assets/js/site.js
@@ -1,0 +1,113 @@
+async function fetchProjects() {
+  const response = await fetch('data/projects.json');
+  if (!response.ok) {
+    throw new Error(`Failed to load projects: ${response.status}`);
+  }
+
+  const data = await response.json();
+  return Array.isArray(data) ? data : [];
+}
+
+function createProjectCard(project) {
+  const hasLink = Boolean(project.url);
+  const card = document.createElement(hasLink ? 'a' : 'div');
+  card.className =
+    'flex h-full flex-col gap-3 rounded-lg border border-gray-200 bg-white p-4 text-left shadow-sm transition hover:border-blue-500 hover:shadow';
+
+  if (hasLink) {
+    card.href = project.url;
+    const isExternal = /^https?:\/\//i.test(project.url) && !project.url.startsWith(location.origin);
+    if (isExternal) {
+      card.target = '_blank';
+      card.rel = 'noopener noreferrer';
+    }
+  }
+
+  if (project.image) {
+    const img = document.createElement('img');
+    img.src = project.image;
+    img.alt = project.title ? `${project.title} cover` : 'Project cover';
+    img.loading = 'lazy';
+    img.className = 'h-40 w-full rounded-md object-cover';
+    card.appendChild(img);
+  }
+
+  if (project.date) {
+    const date = document.createElement('p');
+    date.className = 'text-xs font-semibold uppercase tracking-wide text-blue-600';
+    date.textContent = project.date;
+    card.appendChild(date);
+  }
+
+  const title = document.createElement('h3');
+  title.className = 'text-lg font-semibold text-gray-900';
+  title.textContent = project.title || 'Untitled project';
+  card.appendChild(title);
+
+  if (project.description) {
+    const description = document.createElement('p');
+    description.className = 'text-sm leading-6 text-gray-600';
+    description.textContent = project.description;
+    card.appendChild(description);
+  }
+
+  return card;
+}
+
+async function hydrateProjects(container) {
+  try {
+    const featuredOnly = container.hasAttribute('data-projects-featured');
+    const limitAttr = container.getAttribute('data-projects-limit');
+    const limit = limitAttr ? Number.parseInt(limitAttr, 10) : undefined;
+
+    let projects = await fetchProjects();
+
+    if (featuredOnly) {
+      projects = projects.filter((item) => item.featured);
+    }
+
+    if (typeof limit === 'number' && Number.isFinite(limit)) {
+      projects = projects.slice(0, limit);
+    }
+
+    if (!projects.length) {
+      container.innerHTML =
+        '<p class="col-span-full text-center text-sm text-gray-500">Projects will appear here soon.</p>';
+      return;
+    }
+
+    const fragment = document.createDocumentFragment();
+    projects.forEach((project) => {
+      fragment.appendChild(createProjectCard(project));
+    });
+
+    container.innerHTML = '';
+    container.appendChild(fragment);
+  } catch (error) {
+    console.error(error);
+    container.innerHTML =
+      '<p class="col-span-full text-center text-sm text-red-600">Unable to load projects right now.</p>';
+  }
+}
+
+function setActiveNav() {
+  const currentPath = window.location.pathname.split('/').pop() || 'index.html';
+  const normalized = currentPath || 'index.html';
+
+  document.querySelectorAll('[data-nav] a').forEach((link) => {
+    const href = link.getAttribute('href');
+    const isMatch = href === normalized || (href === 'index.html' && normalized === '');
+    if (isMatch) {
+      link.classList.add('text-blue-600', 'font-semibold');
+      link.classList.remove('text-gray-600');
+      link.setAttribute('aria-current', 'page');
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  setActiveNav();
+  document.querySelectorAll('[data-projects]').forEach((container) => {
+    hydrateProjects(container);
+  });
+});

--- a/data/projects.json
+++ b/data/projects.json
@@ -1,0 +1,61 @@
+[
+  {
+    "title": "Hosting",
+    "date": "May 20, 2025",
+    "description": "How I host my sites and projects.",
+    "url": "hosting.html",
+    "image": "https://lh3.googleusercontent.com/sitesv/AICyYdbwXZg8Rnsqq3HwCV-1bmIDxDpwDdUIFsOPJw5pQG-38u9v51goerR8W76NsI3TIrPBvYMtE8DsA0TGVLOrXJhaRmashwNec7uwV2Q1izccOjLzfCEFTs-jm9F8nupvoDI1LMLofO2w0eFwWPPmWS6VPILRPCFfuHg2T6CDLYby4L1UVEfLNqgGnmU=w1280",
+    "featured": true
+  },
+  {
+    "title": "ReSite",
+    "date": "February 20, 2025",
+    "description": "My latest project, a service for making sites.",
+    "url": "https://resite.web.app",
+    "image": "https://lh3.googleusercontent.com/sitesv/AICyYdbN97kvd7Vn7g60DIf5X9ltGmU167eQFXqgz__s2IvKP6Efy50CejcGQ01W9H-Zm8Q0-ZXSQ5bjoPeiPC9ZCurSy6-poSBXzOLLS5k_SsliTKHry-zaElB4qRP_ewQriEP_FjpQjgtB7dBSl5vxi2AP-Nkc7M5Xf1BwIPq0GZUnQsDVT_eO1w4TWgke8AB-c1HnlLzMZk2-WXkDL44JUiCcMCiuGrjlIaga=w1280",
+    "featured": true
+  },
+  {
+    "title": "Beat The Bank Online",
+    "date": "Jan 7, 2025 - May 21, 2025",
+    "description": "My online shortcut game!",
+    "url": "https://routinehub.co/shortcut/18289/",
+    "image": "https://lh3.googleusercontent.com/sitesv/AICyYdYpWckJ-9-GyecVTJAVlAxilHpXIbnxzap7o1KSzCl4wJe9miR-lRL6RTWdhn1-7yJIHl8zdOuMwupGxwvQ0hB6ZTQuIf2S0O1-8JOIyYCV3QMXx_bQj315T0OVppDRHFYGac1Svcvj3_mrAiXk9WUgC9Laa0QL3bWWzBOD6SK71DT1xuTGeF5q=w1280",
+    "featured": true
+  },
+  {
+    "title": "iMovie Tools",
+    "date": "April 12, 2025",
+    "description": "A tool to export media and full projects from iMovie.",
+    "url": "https://github.com/SmokeSlate/iMovieTools",
+    "image": "https://lh3.googleusercontent.com/sitesv/AICyYdY0EkfI1CPWXZ-tclmJ5n34yZ2mqwNBX_ENFMNVGPo-PWaDURe1mpxfycmJUlQbWgahRLRK4c3OXXCaV2JbZctSPCCFPKvQFtGPTMKytX8dQ0dC-HT8jldVVG3C-5-iZxKfJqdsj8Z-88yOGNdGt7DxwmYSZi9fY8oD9_wrHLlnF-MREW8s3qXhU3Y=w1280"
+  },
+  {
+    "title": "RoutineHub",
+    "date": "May 21, 2025",
+    "description": "My RoutineHub profile with all my latest shortcuts.",
+    "url": "https://routinehub.co/user/SmokeSlate",
+    "image": "https://lh3.googleusercontent.com/sitesv/AICyYdapOTOJfKXcOlHxWCbu5umMr7nJpn5JmzdHhFKxLADQ2gJbzLpV4d72yv-k5BMykwBRQtcMQjL_dn3vqEYoYQFe0BSG3ywrrzsP3lXmGM_6a-oAzjzQNNPA1mNzoRN5S3rcOA6VoWTf_UDp2-VE6KLPCC3_3ccT0ND9HL0Xfn9CM1OSt8AOaviv5Y2QnZo9_u5gzabLaly7Vb2vQvFOW-hoHy5Kl9ZAoOmyqg=w1280"
+  },
+  {
+    "title": "Calculator Games",
+    "date": "May 21, 2025",
+    "description": "My TI-84 game collection.",
+    "url": "https://calgames.web.app",
+    "image": "https://lh3.googleusercontent.com/sitesv/AICyYdas8JAnQhUEAQ7XuUplA-LtapmIRwe8aBhCzSyvyFYFF74vYPsIZR90ZdUfRCghvyVYe3h0WYzPPlyzkG-tt_jNmrU9HbghcNN6Z1QrldpmljIPDV6g2GckftqZb1CL39HpOTmA-TvZJNxmjK_PZf3UqkdTjUkkOZGAtXkGxKChIjtMcgYmt8Nbphe-8tHBotb6R9m-b1klciCWyQZuCzECwzsCwHKRNYZ-zoENwDFEamGXpVsUVZIoMVlGcc=w1280"
+  },
+  {
+    "title": "Icon Maker",
+    "date": "February 15, 2024",
+    "description": "Make icons for your iOS home screen.",
+    "url": "https://routinehub.co/shortcut/12219",
+    "image": "https://lh3.googleusercontent.com/sitesv/AICyYdauPP36Qa0T3uAUoGPBZdHj1xuUpRYoXSOgquNs10QAQfFlvDmwLOehlrCZxhyv6qWDphuNE8iE_huMGd7-sEEyzDhZPa3px5gvi44EVWAmmU7BQgOZAf2EWwBRuE784xz1hj_O5HOM60O_jotKMB49mWJD2J76lSuggLq-4jQQVnauqpMsCXQyzKI-yycOKUF7X411sNYZ-zoENwDFEamGXpVsUVZIoMVlGcc=w1280"
+  },
+  {
+    "title": "Wordle Trainer",
+    "date": "May 21, 2025",
+    "description": "My custom Wordle with a built-in hint.",
+    "url": "https://wordle.smokeslate.xyz",
+    "image": "https://lh3.googleusercontent.com/sitesv/AICyYdaa7lyUVk_BYo3s0ieAs2-mX752_sW_oazcPOWKyRHnx2ieu7ru_HpEiNdYR6HVJusZd41wrZCS-pgy31NRqXlSP8_QcVwbDPxFW3e7ws9_LG-QH4eulXw6tI76DpyeClTUtjD7HsKao99BqZqYffBfvYGe7LUG6mJ1ZkS7kUA9Z_zhVJKjC-S6=w1280"
+  }
+]

--- a/discord.html
+++ b/discord.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SmokeSlate — Discord</title>
+    <meta name="description" content="Join SmokeSlate on Discord." />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            fontFamily: {
+              sans: ['"Work Sans"', 'ui-sans-serif', 'system-ui'],
+            },
+          },
+        },
+      };
+    </script>
+  </head>
+  <body class="bg-white font-sans text-gray-900">
+    <header class="border-b bg-white">
+      <div
+        class="mx-auto flex max-w-5xl flex-col gap-4 px-4 py-6 sm:flex-row sm:items-center sm:justify-between"
+      >
+        <a class="text-2xl font-semibold text-gray-900" href="index.html">SmokeSlate</a>
+        <nav class="flex gap-6 text-sm font-medium text-gray-600" data-nav>
+          <a class="text-gray-600 hover:text-blue-600" href="index.html">Home</a>
+          <a class="text-gray-600 hover:text-blue-600" href="projects.html">Projects</a>
+          <a class="text-gray-600 hover:text-blue-600" href="about.html">About Me</a>
+        </nav>
+      </div>
+    </header>
+
+    <main class="py-16">
+      <div class="mx-auto max-w-3xl px-4 text-center">
+        <h1 class="text-4xl font-semibold text-gray-900 sm:text-5xl">Discord</h1>
+        <div class="mt-8 space-y-4 text-base leading-relaxed text-gray-700">
+          <p>The community server is still getting ready.</p>
+          <p>Check back soon for shortcuts talk, beta testing, and project updates!</p>
+        </div>
+      </div>
+    </main>
+
+    <footer class="border-t bg-gray-50">
+      <div class="mx-auto max-w-5xl px-4 py-8 text-center text-sm text-gray-600">
+        <p class="font-semibold text-gray-700">SmokeSlate</p>
+        <p class="mt-1">®2022-2025 All Rights Reserved</p>
+      </div>
+    </footer>
+
+    <script src="assets/js/site.js" defer></script>
+  </body>
+</html>

--- a/github.html
+++ b/github.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SmokeSlate — GitHub</title>
+    <meta name="description" content="Find SmokeSlate projects on GitHub." />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            fontFamily: {
+              sans: ['"Work Sans"', 'ui-sans-serif', 'system-ui'],
+            },
+          },
+        },
+      };
+    </script>
+  </head>
+  <body class="bg-white font-sans text-gray-900">
+    <header class="border-b bg-white">
+      <div
+        class="mx-auto flex max-w-5xl flex-col gap-4 px-4 py-6 sm:flex-row sm:items-center sm:justify-between"
+      >
+        <a class="text-2xl font-semibold text-gray-900" href="index.html">SmokeSlate</a>
+        <nav class="flex gap-6 text-sm font-medium text-gray-600" data-nav>
+          <a class="text-gray-600 hover:text-blue-600" href="index.html">Home</a>
+          <a class="text-gray-600 hover:text-blue-600" href="projects.html">Projects</a>
+          <a class="text-gray-600 hover:text-blue-600" href="about.html">About Me</a>
+        </nav>
+      </div>
+    </header>
+
+    <main class="py-16">
+      <div class="mx-auto max-w-3xl px-4 text-center">
+        <h1 class="text-4xl font-semibold text-gray-900 sm:text-5xl">GitHub</h1>
+        <div class="mt-8 space-y-4 text-base leading-relaxed text-gray-700">
+          <p>My GitHub profile is the best place to see my open-source projects.</p>
+          <p>
+            You can follow my repositories, explore commit history, and open issues if you find a bug or have an idea to share.
+          </p>
+          <p>
+            Visit <a class="text-blue-600 hover:underline" href="https://github.com/SmokeSlate">github.com/SmokeSlate</a> for the
+            latest updates.
+          </p>
+        </div>
+      </div>
+    </main>
+
+    <footer class="border-t bg-gray-50">
+      <div class="mx-auto max-w-5xl px-4 py-8 text-center text-sm text-gray-600">
+        <p class="font-semibold text-gray-700">SmokeSlate</p>
+        <p class="mt-1">®2022-2025 All Rights Reserved</p>
+      </div>
+    </footer>
+
+    <script src="assets/js/site.js" defer></script>
+  </body>
+</html>

--- a/hosting.html
+++ b/hosting.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SmokeSlate — Hosting</title>
+    <meta name="description" content="How SmokeSlate hosts projects and experiments." />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            fontFamily: {
+              sans: ['"Work Sans"', 'ui-sans-serif', 'system-ui'],
+            },
+          },
+        },
+      };
+    </script>
+  </head>
+  <body class="bg-white font-sans text-gray-900">
+    <header class="border-b bg-white">
+      <div
+        class="mx-auto flex max-w-5xl flex-col gap-4 px-4 py-6 sm:flex-row sm:items-center sm:justify-between"
+      >
+        <a class="text-2xl font-semibold text-gray-900" href="index.html">SmokeSlate</a>
+        <nav class="flex gap-6 text-sm font-medium text-gray-600" data-nav>
+          <a class="text-gray-600 hover:text-blue-600" href="index.html">Home</a>
+          <a class="text-gray-600 hover:text-blue-600" href="projects.html">Projects</a>
+          <a class="text-gray-600 hover:text-blue-600" href="about.html">About Me</a>
+        </nav>
+      </div>
+    </header>
+
+    <main class="py-16">
+      <div class="mx-auto max-w-3xl px-4 text-center">
+        <h1 class="text-4xl font-semibold text-gray-900 sm:text-5xl">Hosting</h1>
+        <div class="mt-8 space-y-4 text-base leading-relaxed text-gray-700">
+          <p>Hello, I'm SmokeSlate. I use XAMPP for PHP, Google Scripts, and Firebase Hosting for static sites.</p>
+          <p>
+            I host my PHP applications using XAMPP. XAMPP provides an Apache server and MySQL database out of the box, which makes
+            it easy to spin up a working PHP environment without extensive configuration (unless I use it lol).
+          </p>
+          <p>
+            I deploy static and frontend web assets via Firebase Hosting. Firebase makes it easy to push updates with a single CLI
+            command and offers fast, secure hosting with built-in HTTPS and custom domain support.
+          </p>
+          <p>
+            While PHP isn’t natively supported by Firebase Hosting, I often separate the frontend to host on Firebase and use JS to
+            connect to my backend when needed. When I'm developing a simple backend with little to no user data storage, I use
+            Google Apps Script. It has easy Google API integration with a high quota and straightforward collaboration.
+          </p>
+        </div>
+      </div>
+    </main>
+
+    <footer class="border-t bg-gray-50">
+      <div class="mx-auto max-w-5xl px-4 py-8 text-center text-sm text-gray-600">
+        <p class="font-semibold text-gray-700">SmokeSlate</p>
+        <p class="mt-1">®2022-2025 All Rights Reserved</p>
+      </div>
+    </footer>
+
+    <script src="assets/js/site.js" defer></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SmokeSlate</title>
+    <meta
+      name="description"
+      content="SmokeSlate builds websites, apps, shortcuts, Discord bots, and more."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            fontFamily: {
+              sans: ['"Work Sans"', 'ui-sans-serif', 'system-ui'],
+            },
+          },
+        },
+      };
+    </script>
+  </head>
+  <body class="bg-white font-sans text-gray-900">
+    <header class="border-b bg-white">
+      <div
+        class="mx-auto flex max-w-5xl flex-col gap-4 px-4 py-6 sm:flex-row sm:items-center sm:justify-between"
+      >
+        <a class="text-2xl font-semibold text-gray-900" href="index.html">SmokeSlate</a>
+        <nav class="flex gap-6 text-sm font-medium text-gray-600" data-nav>
+          <a class="text-gray-600 hover:text-blue-600" href="index.html">Home</a>
+          <a class="text-gray-600 hover:text-blue-600" href="projects.html">Projects</a>
+          <a class="text-gray-600 hover:text-blue-600" href="about.html">About Me</a>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="border-b bg-gray-50">
+        <div class="mx-auto max-w-5xl px-4 py-16 text-center">
+          <h1 class="text-4xl font-semibold text-gray-900 sm:text-5xl">I'm SmokeSlate,</h1>
+          <p class="mt-4 text-lg text-gray-700">
+            I make websites, apps, shortcuts, Discord bots, run servers and more!
+          </p>
+        </div>
+      </section>
+
+      <section class="py-16">
+        <div class="mx-auto max-w-5xl px-4">
+          <div class="flex items-center justify-between gap-4">
+            <h2 class="text-2xl font-semibold text-gray-900">Projects</h2>
+            <a class="text-sm font-medium text-blue-600 hover:underline" href="projects.html"
+              >See all</a
+            >
+          </div>
+          <div
+            class="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3"
+            data-projects
+            data-projects-featured="true"
+            data-projects-limit="6"
+          >
+            <p class="col-span-full text-center text-sm text-gray-500">Loading projects…</p>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="border-t bg-gray-50">
+      <div class="mx-auto max-w-5xl px-4 py-8 text-center text-sm text-gray-600">
+        <p class="font-semibold text-gray-700">SmokeSlate</p>
+        <p class="mt-1">®2022-2025 All Rights Reserved</p>
+      </div>
+    </footer>
+
+    <script src="assets/js/site.js" defer></script>
+  </body>
+</html>

--- a/projects.html
+++ b/projects.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SmokeSlate — Projects</title>
+    <meta name="description" content="Browse SmokeSlate projects, shortcuts, and tools." />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            fontFamily: {
+              sans: ['"Work Sans"', 'ui-sans-serif', 'system-ui'],
+            },
+          },
+        },
+      };
+    </script>
+  </head>
+  <body class="bg-white font-sans text-gray-900">
+    <header class="border-b bg-white">
+      <div
+        class="mx-auto flex max-w-5xl flex-col gap-4 px-4 py-6 sm:flex-row sm:items-center sm:justify-between"
+      >
+        <a class="text-2xl font-semibold text-gray-900" href="index.html">SmokeSlate</a>
+        <nav class="flex gap-6 text-sm font-medium text-gray-600" data-nav>
+          <a class="text-gray-600 hover:text-blue-600" href="index.html">Home</a>
+          <a class="text-gray-600 hover:text-blue-600" href="projects.html">Projects</a>
+          <a class="text-gray-600 hover:text-blue-600" href="about.html">About Me</a>
+        </nav>
+      </div>
+    </header>
+
+    <main class="py-16">
+      <div class="mx-auto max-w-5xl px-4">
+        <header class="mb-12 text-center">
+          <h1 class="text-4xl font-semibold text-gray-900 sm:text-5xl">Projects</h1>
+          <p class="mt-4 text-base text-gray-700">
+            A collection of the sites, shortcuts, and experiments I've been building lately.
+          </p>
+        </header>
+
+        <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3" data-projects>
+          <p class="col-span-full text-center text-sm text-gray-500">Loading projects…</p>
+        </div>
+      </div>
+    </main>
+
+    <footer class="border-t bg-gray-50">
+      <div class="mx-auto max-w-5xl px-4 py-8 text-center text-sm text-gray-600">
+        <p class="font-semibold text-gray-700">SmokeSlate</p>
+        <p class="mt-1">®2022-2025 All Rights Reserved</p>
+      </div>
+    </footer>
+
+    <script src="assets/js/site.js" defer></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- restyle each page with a clean Tailwind-powered header, hero, and footer to closely mirror the original Google Site look
- keep project listings simple by hydrating Tailwind card grids from the shared JSON dataset and highlighting the active navigation link
- drop the bespoke CSS bundle now that the CDN-delivered Tailwind classes cover the layout and typography needs

## Testing
- python -m json.tool data/projects.json > /tmp/projects_pretty.json

------
https://chatgpt.com/codex/tasks/task_e_68ceef29c638833084e30e919e3d6f65